### PR TITLE
Change 'setfiletype' to 'set ft='

### DIFF
--- a/contrib/vim-parti-time/ftdetect/parti-time.vim
+++ b/contrib/vim-parti-time/ftdetect/parti-time.vim
@@ -1,2 +1,2 @@
 " ftdetect/parti-time.vim
-autocmd BufNewFile,BufRead *.tl setfiletype parti-time
+autocmd BufNewFile,BufRead *.tl set ft=parti-time


### PR DESCRIPTION
setfiletype only changes the file type when it's not already been set by other autocommands. I.e. it doesn't override the filetype, if it's already been set.

We *do* want to override it though, so use 'set ft'.

---

If we don't override the file type, it gets set to 'teal', and our syntax highlighting doesn't work.