### PR TITLE
Rolf/editing helper

### DIFF
--- a/contrib/vim-parti-time/ftdetect/parti-time.vim
+++ b/contrib/vim-parti-time/ftdetect/parti-time.vim
@@ -1,2 +1,2 @@
 " ftdetect/parti-time.vim
-autocmd BufNewFile,BufRead *.tl setfiletype parti-time
+autocmd BufNewFile,BufRead *.tl set ft=parti-time

--- a/contrib/vim-parti-time/ftplugin/parti-time.vim
+++ b/contrib/vim-parti-time/ftplugin/parti-time.vim
@@ -1,0 +1,14 @@
+" 5 spaces is what the syntax of parti-time files requires, setting
+" everything as such thus makes working with them much easier
+
+" all tabs get converted to spaces
+setlocal expandtab
+
+" a tab takes 5 spaces
+setlocal tabstop=5
+
+" shifting left or right also uses 5 spaces
+setlocal shiftwidth=5
+
+" pressing the 'Tab' key will indent 5 spaces
+setlocal softtabstop=5


### PR DESCRIPTION
Less typing is more good.

As the parti-time syntax requires 5 spaces for adding partition notes, make it so editing with that is much easier.