### PR TITLE
#6 Default to tl format for files without extension

### DIFF
--- a/src/main/clj/parti_time/input/api.clj
+++ b/src/main/clj/parti_time/input/api.clj
@@ -2,14 +2,11 @@
 
 
 (defn file-extension [filename]
-  (re-find #"(?<=\.)[^.]+$" filename))
+  (or (re-find #"(?<=\.)[^.]+$" filename)
+      "tl"))
 
 (defmulti read-timeline
   file-extension)
-
-(defmethod read-timeline nil [filename]
-  (throw (RuntimeException.
-          (str "Filename extension for given file '" filename "' could not be detected"))))
 
 (defmethod read-timeline :default [filename]
   (throw (RuntimeException.

--- a/src/main/clj/parti_time/input/tl.clj
+++ b/src/main/clj/parti_time/input/tl.clj
@@ -55,4 +55,6 @@
       import-timeline))
 
 (defmethod api/read-timeline "tl" [filename]
-  (read-timeline filename))
+  (if (= filename "-")
+    (read-timeline *in*)
+    (read-timeline filename)))

--- a/src/main/clj/parti_time/output/api.clj
+++ b/src/main/clj/parti_time/output/api.clj
@@ -1,14 +1,11 @@
 (ns parti-time.output.api)
 
 (defn file-extension [filename timeline]
-  (re-find #"(?<=\.)[^.]+$" filename))
+  (or (re-find #"(?<=\.)[^.]+$" filename)
+      "tl"))
 
 (defmulti write-timeline
   file-extension)
-
-(defmethod write-timeline nil [filename timeline]
-  (throw (RuntimeException.
-          (str "Filename extension for given file '" filename "' could not be detected"))))
 
 (defmethod write-timeline :default [filename timeline]
   (throw (RuntimeException.

--- a/src/main/clj/parti_time/output/tl.clj
+++ b/src/main/clj/parti_time/output/tl.clj
@@ -37,4 +37,6 @@
        (spit filename)))
   
 (defmethod api/write-timeline "tl" [filename timeline]
-  (write-timeline filename timeline))
+  (if (= filename "-")
+    (write-timeline *out* timeline))
+    (write-timeline filename timeline))

--- a/src/test/clj/parti_time/input/api_test.clj
+++ b/src/test/clj/parti_time/input/api_test.clj
@@ -3,14 +3,7 @@
               [parti-time.input.api :as sut]))
 
 (t/deftest read-timeline-multimethod
-  (t/testing "Error case"
-    (t/is (thrown-with-msg? RuntimeException #"Filename extension .* could not be detected"
-                            (sut/read-timeline "somefile"))
-          "Empty filename")
-    (t/is (thrown-with-msg? RuntimeException #"Filename extension .* could not be detected"
-                            (sut/read-timeline "somefile"))
-          "Filename without extension"))
   (t/testing "Default case"
     (t/is (thrown-with-msg? RuntimeException #"parti-time does not know .* how to read"
                             (sut/read-timeline "somefile.abc"))
-          "Filename without extension")))
+          "Filename with unknown extension")))

--- a/src/test/clj/parti_time/output/api_test.clj
+++ b/src/test/clj/parti_time/output/api_test.clj
@@ -3,14 +3,7 @@
               [parti-time.input.api :as sut]))
 
 (t/deftest write-timeline-multimethod
-  (t/testing "Error case"
-    (t/is (thrown-with-msg? RuntimeException #"Filename extension .* could not be detected"
-                            (sut/read-timeline "somefile"))
-          "Empty filename")
-    (t/is (thrown-with-msg? RuntimeException #"Filename extension .* could not be detected"
-                            (sut/read-timeline "somefile"))
-          "Filename without extension"))
   (t/testing "Default case"
     (t/is (thrown-with-msg? RuntimeException #"parti-time does not know .* how to read"
                             (sut/read-timeline "somefile.abc"))
-          "Filename without extension")))
+          "Filename with unknown extension")))


### PR DESCRIPTION
* Support to tl format for files without extension
* Support reading tl files from stdin (by passing the "magic" filename `-`)