### PR TITLE
fix trailing timebits bug in days report

### DIFF
--- a/src/main/clj/parti_time/report/days.clj
+++ b/src/main/clj/parti_time/report/days.clj
@@ -50,7 +50,7 @@
                  :as day}]
   (str (.format date (DateTimeFormatter/ofPattern "yyyy-MM-dd E"))
        "  "
-       (apply str (str (clojure.string/join " " (map (partial apply str) (partition 4 project-bits)))))
+       (apply str (str (clojure.string/join " " (map (partial apply str) (partition-all 4 project-bits)))))
        "\n"))
 
 (defn days-report [timeline]

--- a/src/test/clj/parti_time/report/days_test.clj
+++ b/src/test/clj/parti_time/report/days_test.clj
@@ -57,7 +57,7 @@
     :project "Customer Z 2019-08"
     :occupations ["Automated DEV host setup"
                   "Build pipelines"]}
-   {:start-time (time/parse-iso-date-time "2019-08-13t18:00")
+   {:start-time (time/parse-iso-date-time "2019-08-13t18:15")
     :project "Private"
     :occupations []}])
 
@@ -108,5 +108,5 @@
               "               |              |              |              |              |              |              |              |              |\n"
               "               |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |\n"
               "2019-08-12 Mon                              . .... ---. .... .... .... ..   .... .... .... ...   ... ..                                \n"
-              "2019-08-13 Tue                              . ....    . .... .... .... ..   .... .... .... .... .--- ____\n")
+              "2019-08-13 Tue                              . ....    . .... .... .... ..   .... .... .... .... .--- ____ _\n")
              (sut/days-report example-timeline)))))


### PR DESCRIPTION
When a day didn't end with a full hour, all timebits after the last full hour were ignored in the `days` report.

Unfortunately, the unit test which should have caught this problem by coincidence happened to end on a full hour and hence didn't reproduce this issue.

This PR adjusts the unit test and fixes the problem by using [`partition-all`](https://clojuredocs.org/clojure.core/partition-all) (which emits trailing partitions with fewer elements) instead of [`partition`](https://clojuredocs.org/clojure.core/partition) (which drops those trailing partitions).