### PR TITLE
Add link to google_sheets_api docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ In the presented example, you can quickly make simple observations:
 * The time-window between 0700 and 0745 has been used differently: On 2019-08-12 it was used for Metamorphant, on 2019-08-13 for private activities.
 * At the end of 2019-08-13 there has been some Metamorphant activity and some Customer Z activity
 
+### Getting started with the Google Timesheet Integration
+
+See the [dedicated docs](docs/developer_docs/google_sheets_api.md).
+
+
 # Development
 
 ## Prerequisites

--- a/docs/developer_docs/google_sheets_api.md
+++ b/docs/developer_docs/google_sheets_api.md
@@ -25,7 +25,7 @@ This recipe is mostly equivalent to the setup described in the [Java Quickstart 
   * Name: "parti-time CLI"
 * Download `credentials.json` to `~/.config/parti-time/credentials.json`
 
-# How does a metamorphant Google Sheet format look like?
+# What does a metamorphant Google Sheet format look like?
 
 In order to use the google sheet download/append features, you will need a Google Sheet in a metamorphant compatible format.
 


### PR DESCRIPTION
Because I didn't find them when looking.  Mostly I didn't expect to have to go into the `developer_docs` as a user who wants to use one of the features of the program.