### PR TITLE
enable append to use the 2026 Zeitnachweis format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [?.?.?] - Irresistable Inn (Unreleased)
 
+## [1.5.3] - Hyper Happening (2025-01-08)
+- Fix: Support 2026 Metamorphant Google Time Sheets
+
 ## [1.5.2] - Hyper Happening (2025-12-01)
 - Fix: Allow 24:00 times in Google Sheets
 

--- a/src/main/clj/parti_time/google_sheets/client.clj
+++ b/src/main/clj/parti_time/google_sheets/client.clj
@@ -52,10 +52,13 @@
   will return the third row. 1:3 and 3:1 are equivalent and both
   return the first until including the third row. A1:B3 returns the
   first 3 rows containing the first 2 columns."
-  [sheet-id range]
-  (gsheets/values-get$ (credentials/auth!)
-                       {:spreadsheetId sheet-id
-                        :range range}))
+  ([sheet-id range]
+   (get-cells sheet-id range {}))
+  ([sheet-id range options]
+   (gsheets/values-get$ (credentials/auth!)
+                        (merge {:spreadsheetId sheet-id
+                                :range range}
+                               options))))
 
 (defn get-last-row
   "get-last-row returns the last row in a sheet.

--- a/src/main/clj/parti_time/google_sheets/timeline.clj
+++ b/src/main/clj/parti_time/google_sheets/timeline.clj
@@ -17,6 +17,12 @@
   (when-not (= actual expected)
     (throw (RuntimeException. (format "Assertion failed: Value '%s' does not equal expected value '%s'." actual expected)))))
 
+(defn assert-in
+  [actual
+   expected-coll]
+  (when-not (contains? expected-coll actual)
+    (throw (RuntimeException. (format "Assertion failed: Value '%s' is not in collection of expected values '%s'." actual expected-coll)))))
+
 (defn assert-non-blank
   [value]
   (when (clojure.string/blank? value)
@@ -26,8 +32,11 @@
   [google-sheet-id]
   (let [[[title name]
          empty
-         header-row] (:values (parti-time.google-sheets.client/get-cells google-sheet-id "A1:F3"))]
-    (assert-equals title "Zeitnachweis")
+         header-row] (:values (parti-time.google-sheets.client/get-cells google-sheet-id "A1:F3"
+                                                                         {:valueRenderOption "FORMULA"}))]
+    (assert-in title #{"Zeitnachweis"         ; 2025 format
+                       "=Konfiguration!$B$13" ; 2026 format
+                       })
     (assert-non-blank name)
     (assert-equals empty [])
     (assert-equals header-row standard-header-row)))


### PR DESCRIPTION
In 2026, the timesheets at metamorphant got vamped up. To continue using `pt append` for google sheets, the header checks needed to be adjusted.
